### PR TITLE
Changes for 2017.6.1

### DIFF
--- a/greeting-service/pom.xml
+++ b/greeting-service/pom.xml
@@ -42,6 +42,7 @@
       <dependency>
          <groupId>org.jboss.resteasy</groupId>
          <artifactId>resteasy-client</artifactId>
+         <version>${version.resteasy}</version>
          <scope>provided</scope>
       </dependency>
 

--- a/name-service/pom.xml
+++ b/name-service/pom.xml
@@ -33,6 +33,7 @@
       <dependency>
          <groupId>org.jboss.resteasy</groupId>
          <artifactId>resteasy-jaxrs</artifactId>
+         <version>${version.resteasy}</version>
          <scope>provided</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
    <name>WildFly Swarm - Circuit Breaker Booster</name>
 
    <properties>
-      <version.wildfly.swarm>2017.7.0-SNAPSHOT</version.wildfly.swarm>
+      <version.wildfly.swarm>2017.6.1</version.wildfly.swarm>
       <version.resteasy>3.0.19.Final</version.resteasy>
       <version.javax.json>1.0.4</version.javax.json>
       <version.junit>4.12</version.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,10 @@
    <name>WildFly Swarm - Circuit Breaker Booster</name>
 
    <properties>
-      <version.wildfly.swarm>2017.6.0</version.wildfly.swarm>
+      <version.wildfly.swarm>2017.7.0-SNAPSHOT</version.wildfly.swarm>
+      <version.resteasy>3.0.19.Final</version.resteasy>
+      <version.javax.json>1.0.4</version.javax.json>
+      <version.junit>4.12</version.junit>
    </properties>
 
    <modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -28,12 +28,14 @@
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
+         <version>${version.junit}</version>
          <scope>test</scope>
       </dependency>
 
       <dependency>
          <groupId>org.glassfish</groupId>
          <artifactId>javax.json</artifactId>
+         <version>${version.javax.json}</version>
          <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
With recent master, the dependencies in the circuit breaker booster are not managed correctly anymore. This patch fixes it.