### PR TITLE
Move health check config to pom.xml

### DIFF
--- a/greeting-service/pom.xml
+++ b/greeting-service/pom.xml
@@ -40,6 +40,11 @@
       </dependency>
 
       <dependency>
+         <groupId>org.wildfly.swarm</groupId>
+         <artifactId>monitor</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.jboss.resteasy</groupId>
          <artifactId>resteasy-client</artifactId>
          <version>${version.resteasy}</version>
@@ -84,6 +89,16 @@
                            <exclude>webapp</exclude>
                         </excludes>
                      </generator>
+                     <enricher>
+                        <includes>
+                           <include>wildfly-swarm-health-check</include>
+                        </includes>
+                        <config>
+                           <wildfly-swarm-health-check>
+                              <path>/</path>
+                           </wildfly-swarm-health-check>
+                        </config>
+                     </enricher>
                   </configuration>
                </plugin>
             </plugins>

--- a/greeting-service/src/main/fabric8/deployment.yml
+++ b/greeting-service/src/main/fabric8/deployment.yml
@@ -2,19 +2,3 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: ${project.artifactId}
-spec:
-  template:
-    spec:
-      containers:
-        - readinessProbe:
-            httpGet:
-              path: /api/ping
-              port: 8080
-              scheme: HTTP
-          livenessProbe:
-            httpGet:
-              path: /api/ping
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 60
-            periodSeconds: 30

--- a/greeting-service/src/main/java/io/openshift/booster/GreetingEndpoint.java
+++ b/greeting-service/src/main/java/io/openshift/booster/GreetingEndpoint.java
@@ -24,7 +24,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Response;
 
 /**
  *
@@ -44,17 +43,6 @@ public class GreetingEndpoint {
         Greeting greeting = new Greeting(String.format("Hello, %s!", command.execute()));
         CircuitBreakerWebSocketEndpoint.send("isOpen:" + command.isCircuitBreakerOpen());
         return greeting;
-    }
-
-    /**
-     * This endpoint is used as Kubernetes liveness and readiness probe.
-     *
-     * @return the response
-     */
-    @GET
-    @Path("/ping")
-    public Response ping() {
-        return Response.ok().build();
     }
 
     static class Greeting {

--- a/name-service/pom.xml
+++ b/name-service/pom.xml
@@ -76,6 +76,16 @@
                            <exclude>webapp</exclude>
                         </excludes>
                      </generator>
+                     <enricher>
+                        <includes>
+                           <include>wildfly-swarm-health-check</include>
+                        </includes>
+                        <config>
+                           <wildfly-swarm-health-check>
+                              <path>/api/info</path>
+                           </wildfly-swarm-health-check>
+                        </config>
+                     </enricher>
                   </configuration>
                </plugin>
             </plugins>

--- a/name-service/src/main/fabric8/deployment.yml
+++ b/name-service/src/main/fabric8/deployment.yml
@@ -2,19 +2,3 @@ apiVersion: v1
 kind: Deployment
 metadata:
   name: ${project.artifactId}
-spec:
-  template:
-    spec:
-      containers:
-        - readinessProbe:
-            httpGet:
-              path: /api/info
-              port: 8080
-              scheme: HTTP
-          livenessProbe:
-            httpGet:
-              path: /api/info
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 60
-            periodSeconds: 30

--- a/tests/src/test/java/io/openshift/booster/OpenshiftIT.java
+++ b/tests/src/test/java/io/openshift/booster/OpenshiftIT.java
@@ -85,7 +85,7 @@ public class OpenshiftIT {
         });
 
         System.out.println("Pods running, waiting for probes...");
-        String greetingProbeUri = greetingBaseUri + "/api/ping";
+        String greetingProbeUri = greetingBaseUri;
         String nameProbeUri = nameBaseUri + "/api/info";
 
         await().pollInterval(1, TimeUnit.SECONDS).atMost(5, TimeUnit.MINUTES).until(() -> {


### PR DESCRIPTION
https://issues.jboss.org/browse/OBST-199

In this case I wasn't able to remove svc.yml and deployment.yml files as in other boosters, because of name constraints. Without explicitly setting a name in yml file, fmp takes artifactId by default, but chops it to 24 characters length and in this booster's case all names end up ending with `-`, which is invalid.