### PR TITLE
SWARM-1442: Include licenses deliverables.

### DIFF
--- a/greeting-service/pom.xml
+++ b/greeting-service/pom.xml
@@ -120,6 +120,86 @@
             </plugins>
          </build>
       </profile>
+
+      <!-- Activate this profile to generate licenses deliverables -->
+      <!-- Note that we cannot use "licenses" profile id as it's already defined by booster parent -->
+      <profile>
+         <id>generate-licenses</id>
+         <!-- Do not use system property activation - this profile must be inactive when this pom is used during license generation -->
+         <build>
+            <plugins>
+               <plugin>
+                  <artifactId>maven-resources-plugin</artifactId>
+                  <executions>
+                    <execution>
+                      <id>prepare-template</id>
+                      <phase>validate</phase>
+                      <goals>
+                        <goal>copy-resources</goal>
+                      </goals>
+                      <inherited>false</inherited>
+                      <configuration>
+                        <outputDirectory>${basedir}/target</outputDirectory>
+                        <resources>
+                          <resource>
+                            <directory>src/main/resources</directory>
+                            <filtering>true</filtering>
+                          </resource>
+                        </resources>
+                        <escapeString>\</escapeString>
+                      </configuration>
+                    </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.wildfly.swarm</groupId>
+                  <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+                  <version>${version.wildfly.swarm.fraction.plugin}</version>
+                  <executions>
+                     <execution>
+                        <id>generate-licenses</id>
+                        <goals>
+                           <goal>generate-licenses</goal>
+                        </goals>
+                        <configuration>
+                           <licensesTemplate>${project.build.directory}/licenses/licenses-project-template.xml</licensesTemplate>
+                           <downloadSources>true</downloadSources>
+                           <downloadPoms>true</downloadPoms>
+                           <!-- Use custom settings to point to the local maven repo cache -->
+                           <userSettings>${project.build.directory}/licenses/custom-settings.xml</userSettings>
+                           <pomFile>${licenses.pom.file}</pomFile>
+                           <excludes>
+                              <exclude>org/codehaus/plexus/plexus/1.0.4/.*</exclude>
+                           </excludes>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-assembly-plugin</artifactId>
+                  <configuration>
+                     <descriptors>
+                        <descriptor>src/assembly/assembly.xml</descriptor>
+                     </descriptors>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>single</goal>
+                        </goals>
+                        <configuration>
+                           <tarLongFileMode>gnu</tarLongFileMode>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+
    </profiles>
 
 </project>

--- a/greeting-service/src/assembly/assembly.xml
+++ b/greeting-service/src/assembly/assembly.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>license</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/license-project/target/licenses</directory>
+      <outputDirectory/>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/greeting-service/src/main/resources/licenses/custom-settings.xml
+++ b/greeting-service/src/main/resources/licenses/custom-settings.xml
@@ -1,0 +1,35 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+   <profiles>
+      <profile>
+         <id>local-m2</id>
+         <repositories>
+            <repository>
+               <id>localCache</id>
+               <url>file://${user.home}/.m2/repository</url>
+            </repository>
+            <repository>
+               <id>jboss</id>
+               <url>${jboss.repo.url}</url>
+            </repository>
+         </repositories>
+         <pluginRepositories>
+            <pluginRepository>
+               <id>localCache</id>
+               <url>file://${user.home}/.m2/repository</url>
+            </pluginRepository>
+            <pluginRepository>
+               <id>jboss</id>
+               <url>${jboss.repo.url}</url>
+            </pluginRepository>
+         </pluginRepositories>
+      </profile>
+   </profiles>
+
+   <activeProfiles>
+      <activeProfile>local-m2</activeProfile>
+   </activeProfiles>
+</settings>

--- a/greeting-service/src/main/resources/licenses/licenses-html.xsl
+++ b/greeting-service/src/main/resources/licenses/licenses-html.xsl
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="html" encoding="utf-8" standalone="no" media-type="text/html" />
+  <xsl:param name="product"/>
+  <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'" />
+  <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+
+  <xsl:template match="/">
+    <html>
+      <head>
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+        <style>
+          table {
+            border-collapse: collapse;
+          }
+          table, th, td {
+            border: 1px solid navy;
+          }
+          th {
+            text-align: left;
+            background-color: #BCC6CC;
+          }
+          th, td {
+            padding: 2px;
+            text-align: left;
+          }
+          tr:nth-child(even) {
+            background-color: #f2f2f2;
+          }
+        </style>
+      </head>
+      <body>
+        <h2><xsl:value-of select="$product"/></h2>
+        <p>The following material has been provided for informational purposes only, and should not be relied upon or construed as a legal opinion or legal advice.</p>
+        <!-- Read matching templates -->
+        <table>
+          <tr>
+            <th>Package Group</th>
+            <th>Package Artifact</th>
+            <th>Package Version</th>
+            <th>Remote Licenses</th>
+            <th>Local Licenses</th>
+          </tr>
+          <xsl:for-each select="licenseSummary/dependencies/dependency">
+            <xsl:sort select="concat(groupId, '.', artifactId)"/>
+            <tr>
+              <td><xsl:value-of select="groupId"/></td>
+              <td><xsl:value-of select="artifactId"/></td>
+              <td><xsl:value-of select="version"/></td>
+              <td>
+                <xsl:for-each select="licenses/license">
+                  <a href="{./url}"><xsl:value-of select="name"/></a><br/>
+                </xsl:for-each>
+              </td>
+              <td>
+                <xsl:for-each select="licenses/license">
+                  <xsl:variable name="name" select="translate(name,$uppercase,$lowercase)" />
+                  <xsl:variable name="last-index">
+                    <xsl:call-template name="last-index-of">
+                      <xsl:with-param name="txt" select="url"/>
+                      <xsl:with-param name="delimiter" select="'/'"/>
+                    </xsl:call-template>
+                  </xsl:variable>
+                  <xsl:variable name="prefix" select="concat($name,' - ')" />
+                  <xsl:variable name="postfix" select="substring(url,$last-index+1)" />
+                  <xsl:variable name="filename">
+                    <xsl:call-template name="remap-local-filename">
+                      <xsl:with-param name="filename" select="concat($prefix,translate($postfix,$uppercase,$lowercase))" />
+                    </xsl:call-template>
+                  </xsl:variable>
+                  <a href="{$filename}"><xsl:value-of select="$filename"/></a><br/>
+                </xsl:for-each>
+              </td>
+            </tr>
+          </xsl:for-each>
+        </table>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template name="last-index-of">
+    <xsl:param name="txt"/>
+    <xsl:param name="remainder" select="$txt"/>
+    <xsl:param name="delimiter" select="' '"/>
+
+    <xsl:choose>
+      <xsl:when test="contains($remainder, $delimiter)">
+        <xsl:call-template name="last-index-of">
+          <xsl:with-param name="txt" select="$txt"/>
+          <xsl:with-param name="remainder" select="substring-after($remainder, $delimiter)"/>
+          <xsl:with-param name="delimiter" select="$delimiter"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="lastIndex" select="string-length(substring($txt, 1, string-length($txt)-string-length($remainder)))+1"/>
+        <xsl:choose>
+          <xsl:when test="string-length($remainder)=0">
+            <xsl:value-of select="string-length($txt)"/>
+          </xsl:when>
+          <xsl:when test="$lastIndex>0">
+            <xsl:value-of select="($lastIndex - string-length($delimiter))"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="0"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+    <xsl:template name="remap-local-filename">
+        <xsl:param name="filename"/>
+
+        <xsl:choose>
+            <xsl:when test="$filename = 'the antlr 2.7.7 license - antlr-2.7.7.tar.gz'">
+                <xsl:text>the antlr 2.7.7 license.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'the asm bsd license - license.html'">
+                <xsl:text>the asm bsd license.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'the dom4j license - license'">
+                <xsl:text>the dom4j license.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'gnu library general public license, version 2 - lgpl-2.0.txt'">
+                <xsl:text>gnu library general public license, version 2.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'creative commons attribution 2.5 - legalcode'">
+                <xsl:text>creative commons attribution 2.5.html</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'the mit license - mit'">
+                <xsl:text>the mit license - mit.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'common development and distribution license (cddl) and gnu public license v.2 w/classpath exception - cddl-gplv2.html'">
+                <xsl:text>common development and distribution license (cddl) and gnu public license v.2 w_classpath exception - cddl-gplv2.html</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$filename"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/greeting-service/src/main/resources/licenses/licenses-project-template.xml
+++ b/greeting-service/src/main/resources/licenses/licenses-project-template.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2017 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under
+   the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>org.wildfly.swarm</groupId>
+   <artifactId>generate-licence-xml</artifactId>
+   <version>1.0.0</version>
+   <packaging>pom</packaging>
+
+   <properties>
+      <license.directory>\${project.build.directory}/licenses</license.directory>
+   </properties>
+
+   <dependencies>
+      #{dependencies}
+   </dependencies>
+
+   <build>
+      <plugins>
+         <!-- First generate the licenses.xml file -->
+         <plugin>
+            <groupId>org.wildfly.maven.plugins</groupId>
+            <artifactId>licenses-plugin</artifactId>
+            <version>${version.wildfly-licenses-plugin}</version>
+            <inherited>false</inherited>
+            <executions>
+               <execution>
+                  <id>update-licenses-xml</id>
+                  <goals>
+                     <goal>insert-versions</goal>
+                  </goals>
+                  <phase>prepare-package</phase>
+                  <configuration>
+                     <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
+                     <licensesOutputDirectory>${license.directory}</licensesOutputDirectory>
+                     <licensesOutputFile>${license.directory}/licenses.xml</licensesOutputFile>
+                     <includeTransitiveDependencies>false</includeTransitiveDependencies>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <!-- Then transform/fix licenses.xml and generate HTML report -->
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>xml-maven-plugin</artifactId>
+            <version>${version.xml-maven-plugin}</version>
+            <executions>
+               <execution>
+                  <id>transform-licenses</id>
+                  <goals>
+                     <goal>transform</goal>
+                  </goals>
+                  <phase>prepare-package</phase>
+                  <configuration>
+                     <transformationSets>
+                        <transformationSet>
+                           <dir>${license.directory}</dir>
+                           <includes>
+                              <include>licenses.xml</include>
+                           </includes>
+                           <!-- Stylesheet file is located in boms resources -->
+                           <stylesheet>${project.build.directory}/licenses/licenses-transform.xsl</stylesheet>
+                           <outputDir>${license.directory}</outputDir>
+                           <fileMappers>
+                              <fileMapper
+                                 implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                 <targetExtension>.xml</targetExtension>
+                              </fileMapper>
+                           </fileMappers>
+                        </transformationSet>
+                        <transformationSet>
+                           <dir>${license.directory}</dir>
+                           <includes>
+                              <include>licenses.xml</include>
+                           </includes>
+                           <stylesheet>${project.build.directory}/licenses/licenses-html.xsl</stylesheet>
+                           <outputDir>${license.directory}</outputDir>
+                           <fileMappers>
+                              <fileMapper
+                                 implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                 <targetExtension>.html</targetExtension>
+                              </fileMapper>
+                           </fileMappers>
+                           <parameters>
+                              <parameter>
+                                 <name>product</name>
+                                 <value>${project.name} ${project.version}</value>
+                              </parameter>
+                           </parameters>
+                        </transformationSet>
+                     </transformationSets>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <!-- Finally download the licenses files -->
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <version>${version.license-maven-plugin}</version>
+            <inherited>false</inherited>
+            <executions>
+               <execution>
+                  <goals>
+                     <goal>download-licenses</goal>
+                  </goals>
+                  <phase>prepare-package</phase>
+                  <configuration>
+                     <licensesOutputDirectory>${license.directory}</licensesOutputDirectory>
+                     <licensesConfigFile>${license.directory}/licenses.xml</licensesConfigFile>
+                     <includeTransitiveDependencies>false</includeTransitiveDependencies>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
+
+</project>

--- a/greeting-service/src/main/resources/licenses/licenses-transform.xsl
+++ b/greeting-service/src/main/resources/licenses/licenses-transform.xsl
@@ -1,0 +1,271 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="xml" encoding="utf-8"/>
+
+  <!-- Global constants -->
+  <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'"/>
+  <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+  <xsl:variable name="apache_v2_name" select="'Apache Software License, Version 2.0'"/>
+  <xsl:variable name="apache_v2_url" select="'http://www.apache.org/licenses/LICENSE-2.0.txt'"/>
+
+  <xsl:variable name="epl_v1_name" select="'Eclipse Public License, Version 1.0'"/>
+  <xsl:variable name="epl_v1_url" select="'http://www.eclipse.org/legal/epl-v10.html'"/>
+
+  <xsl:variable name="lgpl_v21_name" select="'GNU Lesser General Public License, Version 2.1'"/>
+  <xsl:variable name="lgpl_v21_url" select="'http://www.gnu.org/licenses/lgpl-2.1.html'"/>
+
+  <xsl:variable name="lgpl_v30_name" select="'GNU Lesser General Public License, Version 3'"/>
+  <xsl:variable name="lgpl_v30_url" select="'http://www.gnu.org/licenses/lgpl-3.0-standalone.html'"/>
+
+  <xsl:variable name="bsd_name" select="'The BSD License'"/>
+  <xsl:variable name="bsd_url" select="'http://repository.jboss.org/licenses/bsd.txt'"/>
+
+  <xsl:variable name="bsd_2_name" select="'BSD 2-clause &quot;Simplified&quot; License'"/>
+  <xsl:variable name="bsd_2_url" select="'http://www.opensource.org/licenses/BSD-2-Clause'"/>
+
+  <xsl:variable name="bsd_3_name" select="'BSD 3-clause &quot;New&quot; or &quot;Revised&quot; License'"/>
+  <xsl:variable name="bsd_3_url" select="'http://www.opensource.org/licenses/BSD-3-Clause'"/>
+
+  <xsl:variable name="mit_name" select="'The MIT License'"/>
+  <xsl:variable name="mit_url" select="'http://www.opensource.org/licenses/MIT'"/>
+
+  <xsl:variable name="cddl_name" select="'Common Development and Distribution License (CDDL) and GNU Public License v.2 w/Classpath Exception'"/>
+  <xsl:variable name="cddl_url" select="'https://netbeans.org/cddl-gplv2.html'"/>
+
+  <xsl:variable name="edl_v1_name" select="'Eclipse Distribution License, Version 1.0'"/>
+  <xsl:variable name="edl_v1_url" select="'https://eclipse.org/org/documents/edl-v10.html'"/>
+
+  <xsl:variable name="cca_name" select="'Creative Commons Attribution 2.5'"/>
+  <xsl:variable name="cca_url" select="'http://creativecommons.org/licenses/by/2.5/'"/>
+
+  <xsl:variable name="cpl_name" select="'Common Public License'"/>
+  <xsl:variable name="cpl_url" select="'http://www.opensource.org/licenses/cpl1.0.txt'"/>
+
+  <xsl:variable name="mpl_v11_name" select="'Mozilla Public License 1.1'"/>
+  <xsl:variable name="mpl_v11_url" select="'http://www.mozilla.org/MPL/MPL-1.1.html'"/>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="licenses">
+    <xsl:choose>
+      <xsl:when test="contains(comment(), 'No license information available.')">
+        <xsl:choose>
+          <!-- antlr -->
+          <xsl:when test="ancestor::dependency/groupId/text() = 'antlr'">
+            <licenses>
+              <xsl:text>&#10;        </xsl:text>
+              <xsl:call-template name="license">
+                <xsl:with-param name="name" select="$bsd_3_name"/>
+                <xsl:with-param name="url" select="$bsd_3_url"/>
+              </xsl:call-template>
+              <xsl:text>&#10;      </xsl:text>
+            </licenses>
+          </xsl:when>
+
+          <!-- If nothing matches, leave original values -->
+          <xsl:otherwise>
+            <licenses>
+              <xsl:text>&#10;        </xsl:text>
+              <xsl:text disable-output-escaping="yes">&lt;!--</xsl:text>
+              <xsl:value-of select="current()/comment()"/>
+              <xsl:text disable-output-escaping="yes">--&gt;</xsl:text>
+              <xsl:text>&#10;      </xsl:text>
+            </licenses>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="license">
+    <xsl:choose>
+      <!-- General license name/url fixes/alignment -->
+      <!-- ASL2 -->
+      <xsl:when test="contains(url/text(), 'www.apache.org/licenses/license-2.0') or starts-with(name/text(), 'AL2') or contains(name/text(), 'Apache License, Version 2.0') or contains(name/text(), 'Apache Software License, Version 2.0') or contains(url/text(), 'repository.jboss.org/licenses/apache-2.0') or contains(url/text(), 'www.opensource.org/licenses/apache2.0')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'LICENSE.txt') and (contains(name/text(), 'The Apache Software License, Version 2.0') or contains(name/text(), 'Apache License Version 2.0'))">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'http://www.apache.org/licenses/LICENSE-2.0') and contains(name/text(), '')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- Eclipse -->
+      <xsl:when test="contains(url/text(), 'www.eclipse.org/legal/epl-v10') or contains(url/text(), 'www.eclipse.org/org/documents/epl-v10')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$epl_v1_name"/>
+          <xsl:with-param name="url" select="$epl_v1_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'www.eclipse.org/org/documents/edl-v10.php')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$edl_v1_name"/>
+          <xsl:with-param name="url" select="$edl_v1_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- LGPL -->
+      <xsl:when test="contains(url/text(), 'www.gnu.org/licenses/lgpl-2.1') or contains(url/text(), 'repository.jboss.org/licenses/lgpl') or contains(url/text(), 'repository.jboss.com/licenses/lgpl') or (contains(name/text(), 'LGPL') and contains(name/text(), '2.1'))">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$lgpl_v21_name"/>
+          <xsl:with-param name="url" select="$lgpl_v21_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'www.gnu.org/licenses/lgpl-3.0')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$lgpl_v30_name"/>
+          <xsl:with-param name="url" select="$lgpl_v30_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- BSD -->
+      <xsl:when test="contains(name/text(), 'BSD')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$bsd_name"/>
+          <xsl:with-param name="url" select="$bsd_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(name/text(), 'The 2-Clause BSD License')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$bsd_2_name"/>
+          <xsl:with-param name="url" select="$bsd_2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- MIT -->
+      <xsl:when test="contains(url/text(), 'www.opensource.org/licenses/mit-license') or contains(url/text(), 'www.opensource.org/licenses/MIT') or contains(url/text(), 'jsoup.org/license')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$mit_name"/>
+          <xsl:with-param name="url" select="$mit_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- CDDL -->
+      <xsl:when test="contains(name/text(), 'CDDL/GPLv2+CE')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cddl_name"/>
+          <xsl:with-param name="url" select="$cddl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(name/text(), 'CDDL + GPLv2 with classpath exception')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cddl_name"/>
+          <xsl:with-param name="url" select="$cddl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'glassfish.java.net/public/CDDL+GPL') or contains(url/text(), 'glassfish.dev.java.net/nonav/public/CDDL+GPL') or contains(url/text(), 'glassfish.dev.java.net/public/CDDL+GPL')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cddl_name"/>
+          <xsl:with-param name="url" select="$cddl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- CCA -->
+      <xsl:when test="contains(url/text(), 'creativecommons.org/licenses/by/2.5')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cca_name"/>
+          <xsl:with-param name="url" select="$cca_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- CPL -->
+      <xsl:when test="contains(url/text(), 'www.opensource.org/licenses/cpl1.0')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cpl_name"/>
+          <xsl:with-param name="url" select="$cpl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- Mozilla -->
+      <xsl:when test="contains(url/text(), 'http://www.mozilla.org/MPL/MPL-1.1.html')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$mpl_v11_name"/>
+          <xsl:with-param name="url" select="$mpl_v11_url"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- GAV-specific fixes -->
+      <!-- ASM -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'asm' or contains(ancestor::dependency/groupId/text(), 'org.ow2.asm')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'The Asm BSD License'"/>
+          <xsl:with-param name="url" select="'http://asm.ow2.org/license.html'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- relaxngDatatype -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'com.github.relaxng' and ancestor::dependency/artifactId/text() = 'relaxngDatatype'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$bsd_3_name"/>
+          <xsl:with-param name="url" select="$bsd_3_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- dom4j -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'dom4j' and ancestor::dependency/artifactId/text() = 'dom4j'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'The Dom4j License'"/>
+          <xsl:with-param name="url" select="'https://raw.githubusercontent.com/dom4j/dom4j/master/LICENSE'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- openjdk-orb -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'org.jboss.openjdk-orb' and ancestor::dependency/artifactId/text() = 'openjdk-orb'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'GNU General Public License, Version 2 with the Classpath Exception'"/>
+          <xsl:with-param name="url" select="'http://repository.jboss.org/licenses/gpl-2.0-ce.txt'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- jaxen -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'jaxen' and ancestor::dependency/artifactId/text() = 'jaxen'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'The Jaxen License'"/>
+          <xsl:with-param name="url" select="'http://www.jaxen.org/license.html'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- javassist -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'org.javassist' and ancestor::dependency/artifactId/text() = 'javassist' and name/text() = 'Apache License 2.0'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- If nothing matches, leave original values -->
+      <xsl:otherwise>
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="name/text()"/>
+          <xsl:with-param name="url" select="url/text()"/>
+          <xsl:with-param name="origin" select="'Original'"/>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="license">
+    <xsl:param name="name"/>
+    <xsl:param name="url"/>
+    <xsl:param name="origin" select="'Fixed'"/>
+    <license>
+      <xsl:text>&#10;          </xsl:text>
+      <!-- For debug purposes only -->
+      <!-- xsl:comment><xsl:value-of select="$origin"/></xsl:comment-->
+      <name><xsl:value-of select="$name"/></name>
+      <xsl:text>&#10;          </xsl:text>
+      <url><xsl:value-of select="$url"/></url>
+      <xsl:text>&#10;        </xsl:text>
+    </license>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/name-service/pom.xml
+++ b/name-service/pom.xml
@@ -112,6 +112,86 @@
             </plugins>
          </build>
       </profile>
+
+      <!-- Activate this profile to generate licenses deliverables -->
+      <!-- Note that we cannot use "licenses" profile id as it's already defined by booster parent -->
+      <profile>
+         <id>generate-licenses</id>
+         <!-- Do not use system property activation - this profile must be inactive when this pom is used during license generation -->
+         <build>
+            <plugins>
+               <plugin>
+                  <artifactId>maven-resources-plugin</artifactId>
+                  <executions>
+                    <execution>
+                      <id>prepare-template</id>
+                      <phase>validate</phase>
+                      <goals>
+                        <goal>copy-resources</goal>
+                      </goals>
+                      <inherited>false</inherited>
+                      <configuration>
+                        <outputDirectory>${basedir}/target</outputDirectory>
+                        <resources>
+                          <resource>
+                            <directory>src/main/resources</directory>
+                            <filtering>true</filtering>
+                          </resource>
+                        </resources>
+                        <escapeString>\</escapeString>
+                      </configuration>
+                    </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.wildfly.swarm</groupId>
+                  <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+                  <version>${version.wildfly.swarm.fraction.plugin}</version>
+                  <executions>
+                     <execution>
+                        <id>generate-licenses</id>
+                        <goals>
+                           <goal>generate-licenses</goal>
+                        </goals>
+                        <configuration>
+                           <licensesTemplate>${project.build.directory}/licenses/licenses-project-template.xml</licensesTemplate>
+                           <downloadSources>true</downloadSources>
+                           <downloadPoms>true</downloadPoms>
+                           <!-- Use custom settings to point to the local maven repo cache -->
+                           <userSettings>${project.build.directory}/licenses/custom-settings.xml</userSettings>
+                           <pomFile>${licenses.pom.file}</pomFile>
+                           <excludes>
+                              <exclude>org/codehaus/plexus/plexus/1.0.4/.*</exclude>
+                           </excludes>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-assembly-plugin</artifactId>
+                  <configuration>
+                     <descriptors>
+                        <descriptor>src/assembly/assembly.xml</descriptor>
+                     </descriptors>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>single</goal>
+                        </goals>
+                        <configuration>
+                           <tarLongFileMode>gnu</tarLongFileMode>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+
    </profiles>
 
 </project>

--- a/name-service/src/assembly/assembly.xml
+++ b/name-service/src/assembly/assembly.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>license</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/license-project/target/licenses</directory>
+      <outputDirectory/>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/name-service/src/main/resources/licenses/custom-settings.xml
+++ b/name-service/src/main/resources/licenses/custom-settings.xml
@@ -1,0 +1,35 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+   <profiles>
+      <profile>
+         <id>local-m2</id>
+         <repositories>
+            <repository>
+               <id>localCache</id>
+               <url>file://${user.home}/.m2/repository</url>
+            </repository>
+            <repository>
+               <id>jboss</id>
+               <url>${jboss.repo.url}</url>
+            </repository>
+         </repositories>
+         <pluginRepositories>
+            <pluginRepository>
+               <id>localCache</id>
+               <url>file://${user.home}/.m2/repository</url>
+            </pluginRepository>
+            <pluginRepository>
+               <id>jboss</id>
+               <url>${jboss.repo.url}</url>
+            </pluginRepository>
+         </pluginRepositories>
+      </profile>
+   </profiles>
+
+   <activeProfiles>
+      <activeProfile>local-m2</activeProfile>
+   </activeProfiles>
+</settings>

--- a/name-service/src/main/resources/licenses/licenses-html.xsl
+++ b/name-service/src/main/resources/licenses/licenses-html.xsl
@@ -1,0 +1,143 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="html" encoding="utf-8" standalone="no" media-type="text/html" />
+  <xsl:param name="product"/>
+  <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'" />
+  <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+
+  <xsl:template match="/">
+    <html>
+      <head>
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+        <style>
+          table {
+            border-collapse: collapse;
+          }
+          table, th, td {
+            border: 1px solid navy;
+          }
+          th {
+            text-align: left;
+            background-color: #BCC6CC;
+          }
+          th, td {
+            padding: 2px;
+            text-align: left;
+          }
+          tr:nth-child(even) {
+            background-color: #f2f2f2;
+          }
+        </style>
+      </head>
+      <body>
+        <h2><xsl:value-of select="$product"/></h2>
+        <p>The following material has been provided for informational purposes only, and should not be relied upon or construed as a legal opinion or legal advice.</p>
+        <!-- Read matching templates -->
+        <table>
+          <tr>
+            <th>Package Group</th>
+            <th>Package Artifact</th>
+            <th>Package Version</th>
+            <th>Remote Licenses</th>
+            <th>Local Licenses</th>
+          </tr>
+          <xsl:for-each select="licenseSummary/dependencies/dependency">
+            <xsl:sort select="concat(groupId, '.', artifactId)"/>
+            <tr>
+              <td><xsl:value-of select="groupId"/></td>
+              <td><xsl:value-of select="artifactId"/></td>
+              <td><xsl:value-of select="version"/></td>
+              <td>
+                <xsl:for-each select="licenses/license">
+                  <a href="{./url}"><xsl:value-of select="name"/></a><br/>
+                </xsl:for-each>
+              </td>
+              <td>
+                <xsl:for-each select="licenses/license">
+                  <xsl:variable name="name" select="translate(name,$uppercase,$lowercase)" />
+                  <xsl:variable name="last-index">
+                    <xsl:call-template name="last-index-of">
+                      <xsl:with-param name="txt" select="url"/>
+                      <xsl:with-param name="delimiter" select="'/'"/>
+                    </xsl:call-template>
+                  </xsl:variable>
+                  <xsl:variable name="prefix" select="concat($name,' - ')" />
+                  <xsl:variable name="postfix" select="substring(url,$last-index+1)" />
+                  <xsl:variable name="filename">
+                    <xsl:call-template name="remap-local-filename">
+                      <xsl:with-param name="filename" select="concat($prefix,translate($postfix,$uppercase,$lowercase))" />
+                    </xsl:call-template>
+                  </xsl:variable>
+                  <a href="{$filename}"><xsl:value-of select="$filename"/></a><br/>
+                </xsl:for-each>
+              </td>
+            </tr>
+          </xsl:for-each>
+        </table>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template name="last-index-of">
+    <xsl:param name="txt"/>
+    <xsl:param name="remainder" select="$txt"/>
+    <xsl:param name="delimiter" select="' '"/>
+
+    <xsl:choose>
+      <xsl:when test="contains($remainder, $delimiter)">
+        <xsl:call-template name="last-index-of">
+          <xsl:with-param name="txt" select="$txt"/>
+          <xsl:with-param name="remainder" select="substring-after($remainder, $delimiter)"/>
+          <xsl:with-param name="delimiter" select="$delimiter"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:variable name="lastIndex" select="string-length(substring($txt, 1, string-length($txt)-string-length($remainder)))+1"/>
+        <xsl:choose>
+          <xsl:when test="string-length($remainder)=0">
+            <xsl:value-of select="string-length($txt)"/>
+          </xsl:when>
+          <xsl:when test="$lastIndex>0">
+            <xsl:value-of select="($lastIndex - string-length($delimiter))"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="0"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+    <xsl:template name="remap-local-filename">
+        <xsl:param name="filename"/>
+
+        <xsl:choose>
+            <xsl:when test="$filename = 'the antlr 2.7.7 license - antlr-2.7.7.tar.gz'">
+                <xsl:text>the antlr 2.7.7 license.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'the asm bsd license - license.html'">
+                <xsl:text>the asm bsd license.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'the dom4j license - license'">
+                <xsl:text>the dom4j license.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'gnu library general public license, version 2 - lgpl-2.0.txt'">
+                <xsl:text>gnu library general public license, version 2.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'creative commons attribution 2.5 - legalcode'">
+                <xsl:text>creative commons attribution 2.5.html</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'the mit license - mit'">
+                <xsl:text>the mit license - mit.txt</xsl:text>
+            </xsl:when>
+            <xsl:when test="$filename = 'common development and distribution license (cddl) and gnu public license v.2 w/classpath exception - cddl-gplv2.html'">
+                <xsl:text>common development and distribution license (cddl) and gnu public license v.2 w_classpath exception - cddl-gplv2.html</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$filename"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/name-service/src/main/resources/licenses/licenses-project-template.xml
+++ b/name-service/src/main/resources/licenses/licenses-project-template.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2017 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under
+   the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>org.wildfly.swarm</groupId>
+   <artifactId>generate-licence-xml</artifactId>
+   <version>1.0.0</version>
+   <packaging>pom</packaging>
+
+   <properties>
+      <license.directory>\${project.build.directory}/licenses</license.directory>
+   </properties>
+
+   <dependencies>
+      #{dependencies}
+   </dependencies>
+
+   <build>
+      <plugins>
+         <!-- First generate the licenses.xml file -->
+         <plugin>
+            <groupId>org.wildfly.maven.plugins</groupId>
+            <artifactId>licenses-plugin</artifactId>
+            <version>${version.wildfly-licenses-plugin}</version>
+            <inherited>false</inherited>
+            <executions>
+               <execution>
+                  <id>update-licenses-xml</id>
+                  <goals>
+                     <goal>insert-versions</goal>
+                  </goals>
+                  <phase>prepare-package</phase>
+                  <configuration>
+                     <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
+                     <licensesOutputDirectory>${license.directory}</licensesOutputDirectory>
+                     <licensesOutputFile>${license.directory}/licenses.xml</licensesOutputFile>
+                     <includeTransitiveDependencies>false</includeTransitiveDependencies>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <!-- Then transform/fix licenses.xml and generate HTML report -->
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>xml-maven-plugin</artifactId>
+            <version>${version.xml-maven-plugin}</version>
+            <executions>
+               <execution>
+                  <id>transform-licenses</id>
+                  <goals>
+                     <goal>transform</goal>
+                  </goals>
+                  <phase>prepare-package</phase>
+                  <configuration>
+                     <transformationSets>
+                        <transformationSet>
+                           <dir>${license.directory}</dir>
+                           <includes>
+                              <include>licenses.xml</include>
+                           </includes>
+                           <!-- Stylesheet file is located in boms resources -->
+                           <stylesheet>${project.build.directory}/licenses/licenses-transform.xsl</stylesheet>
+                           <outputDir>${license.directory}</outputDir>
+                           <fileMappers>
+                              <fileMapper
+                                 implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                 <targetExtension>.xml</targetExtension>
+                              </fileMapper>
+                           </fileMappers>
+                        </transformationSet>
+                        <transformationSet>
+                           <dir>${license.directory}</dir>
+                           <includes>
+                              <include>licenses.xml</include>
+                           </includes>
+                           <stylesheet>${project.build.directory}/licenses/licenses-html.xsl</stylesheet>
+                           <outputDir>${license.directory}</outputDir>
+                           <fileMappers>
+                              <fileMapper
+                                 implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                 <targetExtension>.html</targetExtension>
+                              </fileMapper>
+                           </fileMappers>
+                           <parameters>
+                              <parameter>
+                                 <name>product</name>
+                                 <value>${project.name} ${project.version}</value>
+                              </parameter>
+                           </parameters>
+                        </transformationSet>
+                     </transformationSets>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <!-- Finally download the licenses files -->
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <version>${version.license-maven-plugin}</version>
+            <inherited>false</inherited>
+            <executions>
+               <execution>
+                  <goals>
+                     <goal>download-licenses</goal>
+                  </goals>
+                  <phase>prepare-package</phase>
+                  <configuration>
+                     <licensesOutputDirectory>${license.directory}</licensesOutputDirectory>
+                     <licensesConfigFile>${license.directory}/licenses.xml</licensesConfigFile>
+                     <includeTransitiveDependencies>false</includeTransitiveDependencies>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
+
+</project>

--- a/name-service/src/main/resources/licenses/licenses-transform.xsl
+++ b/name-service/src/main/resources/licenses/licenses-transform.xsl
@@ -1,0 +1,271 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="xml" encoding="utf-8"/>
+
+  <!-- Global constants -->
+  <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'"/>
+  <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+  <xsl:variable name="apache_v2_name" select="'Apache Software License, Version 2.0'"/>
+  <xsl:variable name="apache_v2_url" select="'http://www.apache.org/licenses/LICENSE-2.0.txt'"/>
+
+  <xsl:variable name="epl_v1_name" select="'Eclipse Public License, Version 1.0'"/>
+  <xsl:variable name="epl_v1_url" select="'http://www.eclipse.org/legal/epl-v10.html'"/>
+
+  <xsl:variable name="lgpl_v21_name" select="'GNU Lesser General Public License, Version 2.1'"/>
+  <xsl:variable name="lgpl_v21_url" select="'http://www.gnu.org/licenses/lgpl-2.1.html'"/>
+
+  <xsl:variable name="lgpl_v30_name" select="'GNU Lesser General Public License, Version 3'"/>
+  <xsl:variable name="lgpl_v30_url" select="'http://www.gnu.org/licenses/lgpl-3.0-standalone.html'"/>
+
+  <xsl:variable name="bsd_name" select="'The BSD License'"/>
+  <xsl:variable name="bsd_url" select="'http://repository.jboss.org/licenses/bsd.txt'"/>
+
+  <xsl:variable name="bsd_2_name" select="'BSD 2-clause &quot;Simplified&quot; License'"/>
+  <xsl:variable name="bsd_2_url" select="'http://www.opensource.org/licenses/BSD-2-Clause'"/>
+
+  <xsl:variable name="bsd_3_name" select="'BSD 3-clause &quot;New&quot; or &quot;Revised&quot; License'"/>
+  <xsl:variable name="bsd_3_url" select="'http://www.opensource.org/licenses/BSD-3-Clause'"/>
+
+  <xsl:variable name="mit_name" select="'The MIT License'"/>
+  <xsl:variable name="mit_url" select="'http://www.opensource.org/licenses/MIT'"/>
+
+  <xsl:variable name="cddl_name" select="'Common Development and Distribution License (CDDL) and GNU Public License v.2 w/Classpath Exception'"/>
+  <xsl:variable name="cddl_url" select="'https://netbeans.org/cddl-gplv2.html'"/>
+
+  <xsl:variable name="edl_v1_name" select="'Eclipse Distribution License, Version 1.0'"/>
+  <xsl:variable name="edl_v1_url" select="'https://eclipse.org/org/documents/edl-v10.html'"/>
+
+  <xsl:variable name="cca_name" select="'Creative Commons Attribution 2.5'"/>
+  <xsl:variable name="cca_url" select="'http://creativecommons.org/licenses/by/2.5/'"/>
+
+  <xsl:variable name="cpl_name" select="'Common Public License'"/>
+  <xsl:variable name="cpl_url" select="'http://www.opensource.org/licenses/cpl1.0.txt'"/>
+
+  <xsl:variable name="mpl_v11_name" select="'Mozilla Public License 1.1'"/>
+  <xsl:variable name="mpl_v11_url" select="'http://www.mozilla.org/MPL/MPL-1.1.html'"/>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="licenses">
+    <xsl:choose>
+      <xsl:when test="contains(comment(), 'No license information available.')">
+        <xsl:choose>
+          <!-- antlr -->
+          <xsl:when test="ancestor::dependency/groupId/text() = 'antlr'">
+            <licenses>
+              <xsl:text>&#10;        </xsl:text>
+              <xsl:call-template name="license">
+                <xsl:with-param name="name" select="$bsd_3_name"/>
+                <xsl:with-param name="url" select="$bsd_3_url"/>
+              </xsl:call-template>
+              <xsl:text>&#10;      </xsl:text>
+            </licenses>
+          </xsl:when>
+
+          <!-- If nothing matches, leave original values -->
+          <xsl:otherwise>
+            <licenses>
+              <xsl:text>&#10;        </xsl:text>
+              <xsl:text disable-output-escaping="yes">&lt;!--</xsl:text>
+              <xsl:value-of select="current()/comment()"/>
+              <xsl:text disable-output-escaping="yes">--&gt;</xsl:text>
+              <xsl:text>&#10;      </xsl:text>
+            </licenses>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="license">
+    <xsl:choose>
+      <!-- General license name/url fixes/alignment -->
+      <!-- ASL2 -->
+      <xsl:when test="contains(url/text(), 'www.apache.org/licenses/license-2.0') or starts-with(name/text(), 'AL2') or contains(name/text(), 'Apache License, Version 2.0') or contains(name/text(), 'Apache Software License, Version 2.0') or contains(url/text(), 'repository.jboss.org/licenses/apache-2.0') or contains(url/text(), 'www.opensource.org/licenses/apache2.0')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'LICENSE.txt') and (contains(name/text(), 'The Apache Software License, Version 2.0') or contains(name/text(), 'Apache License Version 2.0'))">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'http://www.apache.org/licenses/LICENSE-2.0') and contains(name/text(), '')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- Eclipse -->
+      <xsl:when test="contains(url/text(), 'www.eclipse.org/legal/epl-v10') or contains(url/text(), 'www.eclipse.org/org/documents/epl-v10')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$epl_v1_name"/>
+          <xsl:with-param name="url" select="$epl_v1_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'www.eclipse.org/org/documents/edl-v10.php')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$edl_v1_name"/>
+          <xsl:with-param name="url" select="$edl_v1_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- LGPL -->
+      <xsl:when test="contains(url/text(), 'www.gnu.org/licenses/lgpl-2.1') or contains(url/text(), 'repository.jboss.org/licenses/lgpl') or contains(url/text(), 'repository.jboss.com/licenses/lgpl') or (contains(name/text(), 'LGPL') and contains(name/text(), '2.1'))">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$lgpl_v21_name"/>
+          <xsl:with-param name="url" select="$lgpl_v21_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'www.gnu.org/licenses/lgpl-3.0')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$lgpl_v30_name"/>
+          <xsl:with-param name="url" select="$lgpl_v30_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- BSD -->
+      <xsl:when test="contains(name/text(), 'BSD')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$bsd_name"/>
+          <xsl:with-param name="url" select="$bsd_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(name/text(), 'The 2-Clause BSD License')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$bsd_2_name"/>
+          <xsl:with-param name="url" select="$bsd_2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- MIT -->
+      <xsl:when test="contains(url/text(), 'www.opensource.org/licenses/mit-license') or contains(url/text(), 'www.opensource.org/licenses/MIT') or contains(url/text(), 'jsoup.org/license')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$mit_name"/>
+          <xsl:with-param name="url" select="$mit_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- CDDL -->
+      <xsl:when test="contains(name/text(), 'CDDL/GPLv2+CE')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cddl_name"/>
+          <xsl:with-param name="url" select="$cddl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(name/text(), 'CDDL + GPLv2 with classpath exception')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cddl_name"/>
+          <xsl:with-param name="url" select="$cddl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="contains(url/text(), 'glassfish.java.net/public/CDDL+GPL') or contains(url/text(), 'glassfish.dev.java.net/nonav/public/CDDL+GPL') or contains(url/text(), 'glassfish.dev.java.net/public/CDDL+GPL')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cddl_name"/>
+          <xsl:with-param name="url" select="$cddl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- CCA -->
+      <xsl:when test="contains(url/text(), 'creativecommons.org/licenses/by/2.5')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cca_name"/>
+          <xsl:with-param name="url" select="$cca_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- CPL -->
+      <xsl:when test="contains(url/text(), 'www.opensource.org/licenses/cpl1.0')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$cpl_name"/>
+          <xsl:with-param name="url" select="$cpl_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- Mozilla -->
+      <xsl:when test="contains(url/text(), 'http://www.mozilla.org/MPL/MPL-1.1.html')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$mpl_v11_name"/>
+          <xsl:with-param name="url" select="$mpl_v11_url"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- GAV-specific fixes -->
+      <!-- ASM -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'asm' or contains(ancestor::dependency/groupId/text(), 'org.ow2.asm')">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'The Asm BSD License'"/>
+          <xsl:with-param name="url" select="'http://asm.ow2.org/license.html'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- relaxngDatatype -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'com.github.relaxng' and ancestor::dependency/artifactId/text() = 'relaxngDatatype'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$bsd_3_name"/>
+          <xsl:with-param name="url" select="$bsd_3_url"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- dom4j -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'dom4j' and ancestor::dependency/artifactId/text() = 'dom4j'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'The Dom4j License'"/>
+          <xsl:with-param name="url" select="'https://raw.githubusercontent.com/dom4j/dom4j/master/LICENSE'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- openjdk-orb -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'org.jboss.openjdk-orb' and ancestor::dependency/artifactId/text() = 'openjdk-orb'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'GNU General Public License, Version 2 with the Classpath Exception'"/>
+          <xsl:with-param name="url" select="'http://repository.jboss.org/licenses/gpl-2.0-ce.txt'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- jaxen -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'jaxen' and ancestor::dependency/artifactId/text() = 'jaxen'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="'The Jaxen License'"/>
+          <xsl:with-param name="url" select="'http://www.jaxen.org/license.html'"/>
+        </xsl:call-template>
+      </xsl:when>
+      <!-- javassist -->
+      <xsl:when test="ancestor::dependency/groupId/text() = 'org.javassist' and ancestor::dependency/artifactId/text() = 'javassist' and name/text() = 'Apache License 2.0'">
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="$apache_v2_name"/>
+          <xsl:with-param name="url" select="$apache_v2_url"/>
+        </xsl:call-template>
+      </xsl:when>
+
+      <!-- If nothing matches, leave original values -->
+      <xsl:otherwise>
+        <xsl:call-template name="license">
+          <xsl:with-param name="name" select="name/text()"/>
+          <xsl:with-param name="url" select="url/text()"/>
+          <xsl:with-param name="origin" select="'Original'"/>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="license">
+    <xsl:param name="name"/>
+    <xsl:param name="url"/>
+    <xsl:param name="origin" select="'Fixed'"/>
+    <license>
+      <xsl:text>&#10;          </xsl:text>
+      <!-- For debug purposes only -->
+      <!-- xsl:comment><xsl:value-of select="$origin"/></xsl:comment-->
+      <name><xsl:value-of select="$name"/></name>
+      <xsl:text>&#10;          </xsl:text>
+      <url><xsl:value-of select="$url"/></url>
+      <xsl:text>&#10;        </xsl:text>
+    </license>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/pom-redhat.xml
+++ b/pom-redhat.xml
@@ -31,6 +31,14 @@
       <version.override.jackson>2.7.7</version.override.jackson>
       <version.javax.json>1.0.4</version.javax.json>
       <version.junit>4.12</version.junit>
+      <!-- Licenses - plugins -->
+      <version.wildfly.swarm.fraction.plugin>61</version.wildfly.swarm.fraction.plugin>
+      <version.xml-maven-plugin>1.0.1</version.xml-maven-plugin>
+      <version.license-maven-plugin>1.13</version.license-maven-plugin>
+      <version.wildfly-licenses-plugin>1.0.1</version.wildfly-licenses-plugin>
+      <!-- Licenses - JBoss repo URL used in custom-settings -->
+      <jboss.repo.url>https://maven.repository.redhat.com/ga/</jboss.repo.url>
+      <licenses.pom.file>pom.xml</licenses.pom.file>
    </properties>
 
    <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,14 @@
       <version.resteasy>3.0.19.Final</version.resteasy>
       <version.javax.json>1.0.4</version.javax.json>
       <version.junit>4.12</version.junit>
+      <!-- Licenses - plugins -->
+      <version.wildfly.swarm.fraction.plugin>61</version.wildfly.swarm.fraction.plugin>
+      <version.xml-maven-plugin>1.0.1</version.xml-maven-plugin>
+      <version.license-maven-plugin>1.13</version.license-maven-plugin>
+      <version.wildfly-licenses-plugin>1.0.1</version.wildfly-licenses-plugin>
+      <!-- Licenses - JBoss repo URL used in custom-settings -->
+      <jboss.repo.url>https://repository.jboss.org/nexus/content/groups/public</jboss.repo.url>
+      <licenses.pom.file>pom.xml</licenses.pom.file>
    </properties>
 
    <modules>
@@ -88,6 +96,7 @@
             </configuration>
          </plugin>
       </plugins>
+
    </build>
 
 </project>


### PR DESCRIPTION
Note that for this booster it's not possible to generate the `licenses.xml` without renaming the parent `pom.xml`, i.e. you should:

1. rename `pom-redhat.xml` to `pom.xml` in parent
2. run `mvn clean package -DskipTests -Pgenerate-licenses` for each module