### PR TITLE
[SWARM-1646] fix the S2I flow

### DIFF
--- a/greeting-service/.openshiftio/application.yaml
+++ b/greeting-service/.openshiftio/application.yaml
@@ -74,6 +74,8 @@ objects:
           value: "-pl ${SOURCE_REPOSITORY_DIR}"
         - name: ARTIFACT_DIR
           value: "${SOURCE_REPOSITORY_DIR}/target"
+        - name: ARTIFACT_COPY_ARGS
+          value: "*-swarm.jar"
       type: Source
     triggers:
     - github:

--- a/name-service/.openshiftio/application.yaml
+++ b/name-service/.openshiftio/application.yaml
@@ -74,6 +74,8 @@ objects:
           value: "-pl ${SOURCE_REPOSITORY_DIR}"
         - name: ARTIFACT_DIR
           value: "${SOURCE_REPOSITORY_DIR}/target"
+        - name: ARTIFACT_COPY_ARGS
+          value: "*-swarm.jar"
       type: Source
     triggers:
     - github:


### PR DESCRIPTION
These manual changes to the YAML templates in `.openshiftio` make it
impossible to later regenerate the `application.yaml` files using
the script from Fabric8 Launch, but I tried to regenerate them now
and it seems there have been manual changes before. And even if not,
the diff was quite big, which leads me to believe that regenerating
those YAML templates would be quite risky anyway.