### PR TITLE
[THORN-2448] fix usage of MP RestClient

### DIFF
--- a/greeting-service/pom.xml
+++ b/greeting-service/pom.xml
@@ -57,12 +57,6 @@
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-      <version>${version.resteasy}</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/greeting-service/src/main/java/io/thorntail/example/NameService.java
+++ b/greeting-service/src/main/java/io/thorntail/example/NameService.java
@@ -25,9 +25,9 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.lang.reflect.Method;
 
@@ -36,7 +36,7 @@ import java.lang.reflect.Method;
 public interface NameService {
     @GET
     @Path("/api/name")
-    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
     @CircuitBreaker(requestVolumeThreshold = 3)
     @Fallback(fallbackMethod = "fallback")
     String get();

--- a/name-service/pom.xml
+++ b/name-service/pom.xml
@@ -39,7 +39,6 @@
       <groupId>io.thorntail</groupId>
       <artifactId>microprofile-health</artifactId>
     </dependency>
-
     <!-- We need this because of CorsFilter -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
The `NameService` client interface uses `@Consumes(MediaType.TEXT_PLAIN)`
where it should have been using `@Produces`. This commit fixes that.

It also streamlines the test, which used to divide RestAssured
calls across many small methods, where one method with the entire
RestAssured call chain would suffice and be more readable.